### PR TITLE
Fix message type switch to correct parameter

### DIFF
--- a/src/xml.rs
+++ b/src/xml.rs
@@ -49,19 +49,19 @@ fn parse_mms(element: &ElementData) -> MmsMessage {
     let date = parse_unix_epoch(element.attr("date"));
     let readable_date = element.attr("readable_date").to_owned();
     let contact_name = element.attr("contact_name").to_owned();
-    let msg_type = element.attr("m_type");
-    let kind = match msg_type {
-        "128" => {
+    let msg_box = element.attr("msg_box");
+    let kind = match msg_box {
+        "2" => {
             // sent
             MessageKind::Sent
         }
-        "132" => {
+        "1" => {
             // received
             MessageKind::Received {
                 date_sent: parse_unix_epoch(element.attr("date_sent")),
             }
         }
-        _ => panic!("Unknown message type {:?}", msg_type),
+        _ => panic!("Unknown message box {:?}", msg_box),
     };
     let parts = element.find_child("parts");
     let parts = parts


### PR DESCRIPTION
I was trying to get this to work on some old messages and ran into errors with an unknown message type and dove into a rabbit hole trying to figure out how to understand MMS message type integers, but ended up realizing that this switch just trying to determine if it was a sent or received message and there was another parameter in the XML that had that information (msg_box).